### PR TITLE
BaSP-TG-29: Create Modal component

### DIFF
--- a/src/Components/Shared/Button/button.module.css
+++ b/src/Components/Shared/Button/button.module.css
@@ -173,5 +173,6 @@
     background-color: transparent;
     border: none;
     cursor: pointer;
+    color: inherit;
     font-weight: 800;
 }

--- a/src/Components/Shared/Button/index.jsx
+++ b/src/Components/Shared/Button/index.jsx
@@ -3,7 +3,7 @@ import styles from './button.module.css';
 
 const Button = ({ type, onClick, variant = 'cancelButton', text }) => {
   return (
-    <button type={type ? type : 'button'} className={`${styles[variant]}`} onClick={onClick}>
+    <button type={type ? type : 'button'} className={styles[variant]} onClick={onClick}>
       {text}
     </button>
   );

--- a/src/Components/Shared/Modal/Modal.jsx
+++ b/src/Components/Shared/Modal/Modal.jsx
@@ -1,0 +1,22 @@
+import styles from './modal.module.css';
+
+const Modal = ({ children, variant = 'modal', showModal, closeModal, text, title }) => {
+  if (!showModal) {
+    return null;
+  }
+
+  return (
+    <div className={styles.modalContainer}>
+      <div className={styles[variant]}>
+        <button className={styles.closeButton} onClick={closeModal}>
+          X
+        </button>
+        {title ? <h3>{title}</h3> : null}
+        <p>{text}</p>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/Components/Shared/Modal/Modal.jsx
+++ b/src/Components/Shared/Modal/Modal.jsx
@@ -1,4 +1,5 @@
 import styles from './modal.module.css';
+import Button from '../Button';
 
 const Modal = ({ children, variant = 'modal', showModal, closeModal, text, title }) => {
   if (!showModal) {
@@ -8,9 +9,7 @@ const Modal = ({ children, variant = 'modal', showModal, closeModal, text, title
   return (
     <div className={styles.modalContainer}>
       <div className={styles[variant]}>
-        <button className={styles.closeButton} onClick={closeModal}>
-          X
-        </button>
+        <Button variant={'closeButton'} onClick={closeModal} text="X" />
         {title ? <h3>{title}</h3> : null}
         <p>{text}</p>
         {children}

--- a/src/Components/Shared/Modal/modal.module.css
+++ b/src/Components/Shared/Modal/modal.module.css
@@ -1,0 +1,52 @@
+.modalContainer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, .5);
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .modal, .errorModal, .successModal  {
+    width: 300px;
+    position: relative;
+    border-radius: 7px;
+    display: flex;
+    flex-direction: column;
+    padding: 32px;
+  }
+
+  .modal {
+    background-color: #ffffff;
+    color: #373867;
+  }
+
+  .errorModal {
+    background-color: #F13312;
+    color: #ffffff;
+  }
+
+  .successModal {
+    background-color: #AACE9B;
+    color: #373867;
+  }
+
+  .modal > :not(h3) + p, .errorModal > :not(h3) + p, .successModal > :not(h3) + p {
+    font-weight: 700;
+  }
+
+
+  .closeButton {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    font-weight:800;
+  }
+

--- a/src/Components/Shared/Modal/modal.module.css
+++ b/src/Components/Shared/Modal/modal.module.css
@@ -37,16 +37,3 @@
   .modal > :not(h3) + p, .errorModal > :not(h3) + p, .successModal > :not(h3) + p {
     font-weight: 700;
   }
-
-
-  .closeButton {
-    position: absolute;
-    top: 15px;
-    right: 15px;
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-    color: inherit;
-    font-weight:800;
-  }
-


### PR DESCRIPTION
Ticket: https://trello.com/c/bISJ1t2w/29-create-modal-component

- Create generic modal
- Add styles with CSS for generic modal (confirm and show data).
- Add styles with CSS for error messages.
- Add styles with CSS for success messages
- Use children prop to send the content of the Modal.
- Implement ternary operator to show/hide title. (Error and success messages don't contain title)
- Add text prop to send modal description
- Implement Button component to the Modal.
- Apply fixes requested in the Demo meeting to Button component.

**How to implement this component**: 
In the index file of the component that you are looking to apply this component, import the Modal component: 

`import Modal from '../Shared/Modal/Modal';`

After that, you must add a new useState hook:

`const [showModal, setShowModal] = useState({ delete: false, confirm: false, success: false });`

The number of keys of this object is equal to the number of modals that you are looking to have inside your component. Each key name should match the modal that you are planning to use and each value must be set to false so the modals don't show up by default.

Create a new function that is going to toggle each modal visibility on and off. It receives two arguments: `modal ` is a string containing the key name of the modal that you are looking to toggle on/off and a boolean parameter which recieves true (toggle modal on) or false (toggle modal off)

```
const toggleModal = (modal, isVisible) => {
  setShowModal({ ...showModal, [modal]: isVisible });
};
```

Create a new Modal component. The `showModal` prop must have the key of the object `showModal` that matches the type of modal that you are looking to use. `closeModal` prop must contain a callback with the function `toggleModal(modal, isVisible)` where modal is an string containing the name of the key used before and `isVisible` must always be set to `false` so it toggles that modal off whenever the modal is closed. `title` prop is optional and is used to add a new h3 tag inside of the modal that contains the title. The `text` prop is used to add a description to the modal. The `variant` prop is a string used to set the style of the Modal. The value must match one of the following classes: modal, errorModal, successModal. Also, you can add buttons, inputs, HTML elements and/or JSX logic as children of the Modal that are going to be sent to the component as the `children` prop.

```
<Modal
  showModal={showModal.delete}
  closeModal={() => toggleModal('delete', false)}
  title={'Delete'}
  variant={'errorModal'}
  text={'This a modal to delete'}>
    <input type="text">
    <Button />
</Modal>
```

Finally, you need to create a Button component to open this Modal with the onClick function which must the toggleModal(modal, isVisible) method where the modal parameter is an string with the name of the key used before and isVisible must be a boolean and its value must be true to toggle the modal on. 

`<Button onClick={() => toggleModal('delete', true)} text={"Delete"} />`

If your component contains only one modal, you can instead do:

`const [showModal, setShowModal] = useState(false);`

```
<Modal
  showModal={showModal}
  closeModal={setShowModal(false)}
  title={'Delete'}
  variant={'errorModal'}
  text={'This a modal to delete'} />

<Button onClick={setShowModal(true)} text={"Delete"} />
```
