### PR TITLE
BaSP-TG-86: Hotfix - Show Projects & Show Employees buttons on Projects and Employees pages

### DIFF
--- a/src/Components/Employees/index.jsx
+++ b/src/Components/Employees/index.jsx
@@ -14,6 +14,7 @@ const Employees = () => {
   const params = useParams();
   const { list, isPending, error } = useSelector((state) => state.employees);
   const [showModal, setShowModal] = useState({ info: false, delete: false, success: false });
+  const [projects, saveProjects] = useState([]);
 
   useEffect(() => {
     dispatch(getEmployees());
@@ -57,6 +58,14 @@ const Employees = () => {
     history.push(`employees/form/${id}`);
   };
 
+  const openProjectsModal = (id) => {
+    history.push(`employees/${id}/projects`);
+    toggleModal('info');
+    const data = list.find((employee) => employee._id === id);
+    saveProjects(data.projects);
+    console.log(projects);
+  };
+
   return (
     <section className={styles.container}>
       <Modal
@@ -87,6 +96,23 @@ const Employees = () => {
         text="Employee deleted successfully"
         variant={'successModal'}
       />
+      <Modal
+        showModal={showModal.info}
+        closeModal={() => {
+          toggleModal('info');
+          history.goBack();
+        }}
+        title="Projects List"
+      >
+        {projects.length > 0 ? (
+          <Table
+            headers={['name', 'description', 'startDate', 'endDate', 'clientName']}
+            data={projects}
+          />
+        ) : (
+          <p>This employee has no projects assigned yet</p>
+        )}
+      </Modal>
       <h2>Employees</h2>
       <div className={styles.addButton}>
         <Button
@@ -100,9 +126,19 @@ const Employees = () => {
       ) : (
         <Table
           data={list}
-          headers={['name', 'lastName', 'phone', 'email', 'password', 'status', 'actions']}
+          headers={[
+            'name',
+            'lastName',
+            'phone',
+            'email',
+            'password',
+            'status',
+            'projects',
+            'actions'
+          ]}
           handleDelete={openDeleteModal}
           editItem={editEmployee}
+          showInfo={openProjectsModal}
         />
       )}
     </section>

--- a/src/Components/Employees/index.jsx
+++ b/src/Components/Employees/index.jsx
@@ -63,7 +63,6 @@ const Employees = () => {
     toggleModal('info');
     const data = list.find((employee) => employee._id === id);
     saveProjects(data.projects);
-    console.log(projects);
   };
 
   return (

--- a/src/Components/Shared/Modal/modal.module.css
+++ b/src/Components/Shared/Modal/modal.module.css
@@ -11,7 +11,7 @@
   }
 
   .modal, .errorModal, .successModal  {
-    width: 300px;
+    max-width: 400px;
     position: relative;
     border-radius: 7px;
     display: flex;

--- a/src/Components/Shared/Row/index.jsx
+++ b/src/Components/Shared/Row/index.jsx
@@ -31,7 +31,7 @@ const Row = ({ data, headers, handleDelete, editItem, showInfo }) => {
             <td key={index}>
               <Button
                 onClick={() => {
-                  showInfo(data[header]);
+                  showInfo(data._id);
                 }}
                 text={header}
               />


### PR DESCRIPTION
**Ticket**: https://trello.com/c/gwtoy9Ei/86-hotfix-show-projects-in-employees-modal
**Authors**: @Maxi-SR and @DamianPalavecino 
**Description**:  Fix problem when you click on ‘Projects' button on Employees and ‘Employees’ button on Projects.
**How to test**:  

- Click on the button 'employees' from Projects page. In most cases, it will show a modal with the following paragraph: 'There are no employees in this project' as there is no way to add employees to a project manually to a project on the app yet and when you create a new project from the app, the employees list is empty by default. If the project has employees assigned to it (you can test this using Postman and making a PUT request to '/projects/:id/assignEmployee/' to add new employees), it will display a modal which contains a table with the rate and role of the employees. (more data from the employees is going to be added soon).

- Click on the button 'projects' from the Employees page. In most cases, it will show a modal with the following paragraph: 'This employee has no projects assigned yet' as there is no way to assign projects to an employee manually on the app yet and when you create a new employee from the app, the project list is empty by default. If the employee is assigned to one or more projects (you can test it by making a new PUT request on Postman and updating the employee on '/Employees/:id'), it will display a modal with a table that contains information about the project/s that the employee is in (name, description, startDate, endDate and clientName).