### PR TITLE
BaSP-TG-120: hotfix - problem with employees modal in projects

### DIFF
--- a/src/Components/Shared/Row/index.jsx
+++ b/src/Components/Shared/Row/index.jsx
@@ -6,7 +6,7 @@ const Row = ({ data, headers, handleDelete, editItem, showInfo, assignEmployee }
   const fixDate = (date) => {
     return date.slice(0, 10);
   };
-  const { data: authData } = useSelector((store) => {
+  const { data: authData, role } = useSelector((store) => {
     return store.auth;
   });
 
@@ -34,7 +34,7 @@ const Row = ({ data, headers, handleDelete, editItem, showInfo, assignEmployee }
             </td>
           );
         }
-        if (header === 'role') {
+        if (role.role === 'EMPLOYEE' && header === 'role') {
           const findEmployee = data.employees.find(
             (employee) => employee.employeeId === authData._id
           );


### PR DESCRIPTION
When we click on the button to open the modal with the table of employees, the application breaks.

**Step to reproduce:**

- Log in as Admin
- Go to Projects section
- Click on the employees button

**Expected result**: The modal with the employees list should be displayed correctly.

Contributors: @DamianPalavecino @PilarFernandezC 